### PR TITLE
Newline and 226 response code fixes

### DIFF
--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -198,8 +198,10 @@ module EventMachine
 
       # Called when a response for the CWD or CDUP is received
       def cwd_response(response)
-        @responder = nil
-        call_callback
+        if response && response.code != "226"
+          @responder = nil
+          call_callback
+        end
       end
 
       # Called when a response for the PWD verb is received

--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -262,8 +262,8 @@ module EventMachine
           old_data_buffer = @data_buffer
           @data_buffer = nil
           # parse it into a real form
-          file_list = old_data_buffer.split("\r\n").map do |line|
-            ::Net::FTP::List.parse(line)
+          file_list = old_data_buffer.split("\n").map do |line|
+            ::Net::FTP::List.parse(line.strip)
           end
           call_callback(file_list)
         end


### PR DESCRIPTION
Hi Ben;

I'm thinking about using your em-ftp-client in a project, and I thought I'd share fixes for a couple of small issues I ran into with PureFTPd and vsftpd as servers.

First commit simply splits on newlines and strips carriage returns when splitting response text.

The second commit wraps ControlConnection#cwd_response in a conditional to skip 226 response codes, which is a pattern I see in other responder methods in the class. I don't know if you had another pattern in mind for dealing with 226 responses, but it fixed a problem I had where responses and responders drifted out of sync.

Hope these are useful! Thanks for em-ftp-client, good stuff.

Scott
