### PR TITLE
Fixed RETR problem and implemented STOR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,5 @@
 .bundle
 Gemfile.lock
 pkg/*
-
+.idea
 test_client.rb

--- a/README
+++ b/README
@@ -17,12 +17,14 @@ standard usage would look like:
             ftp.list do |l2|
               puts l2
               puts
-              ftp.stream {|d| puts "STREAMING: #{d.inspect}" }
-              ftp.get("two.txt") do |t1|
-                puts "COMPLETED"
-                puts t1
-                puts
-                EM.stop
+              ftp.put("one.txt") do
+                ftp.stream {|d| puts "STREAMING: #{d.inspect}" }
+                ftp.get("two.txt") do |t1|
+                  puts "COMPLETED"
+                  puts t1
+                  puts
+                  EM.stop
+                end
               end
             end
           end
@@ -32,7 +34,3 @@ standard usage would look like:
 
 This library also includes the class SyncSession, which uses fibers and works
 with em-synchrony.
-
-TODO:
-
-Add support for put/STOR operations

--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -108,7 +108,7 @@ module EventMachine
       def data_connection_closed(data)
         @data_buffer = data
         @data_connection = nil
-        send(@responder) if @responder
+        send(@responder) if @responder and @response.complete?
       end
 
       def callback(&blk)
@@ -237,6 +237,7 @@ module EventMachine
         end
 
         if response && @data_connection
+          @response = response
           #well we still gots to wait for the file
         elsif @data_connection
           #well we need to wait for a response

--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -299,6 +299,7 @@ module EventMachine
       
       def close_response(response=nil)
         close_connection
+        call_callback
       end
     end
   end

--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -171,6 +171,14 @@ module EventMachine
         @responder = :stor_response
       end
       
+      def close
+        if @data_connection
+          raise "Can not close connection while data connection is still open"
+        end
+        send_data("QUIT\r\n")
+        @responder = :close_response
+      end
+
       def list
         send_data("LIST\r\n")
         @responder = :list_response
@@ -288,7 +296,10 @@ module EventMachine
           call_callback(file_list)
         end
       end
-        
+      
+      def close_response(response=nil)
+        close_connection
+      end
     end
   end
 end

--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -166,6 +166,11 @@ module EventMachine
         @responder = :retr_response
       end
 
+      def stor(filename)
+        send_data("STOR #{filename}\r\n")
+        @responder = :stor_response
+      end
+      
       def list
         send_data("LIST\r\n")
         @responder = :list_response
@@ -247,6 +252,18 @@ module EventMachine
           @data_buffer = nil
           call_callback(old_data_buffer)
         end
+      end
+
+      def stor_response(response=nil)
+        if response && response.code != "226"
+          @data_connection.close_connection
+          @responder = nil
+          error(response)
+        end
+
+        @responder = nil
+        @data_buffer = nil
+        call_callback
       end
 
       def list_response(response=nil)

--- a/lib/em-ftp-client/data_connection.rb
+++ b/lib/em-ftp-client/data_connection.rb
@@ -22,6 +22,11 @@ module EventMachine
           @buf = ''
         end
       end
+      
+      def send_file(filename)
+	      send_file_data(filename)
+        close_connection_after_writing
+      end
 
       def unbind
         succeed(@buf)

--- a/lib/em-ftp-client/session.rb
+++ b/lib/em-ftp-client/session.rb
@@ -57,6 +57,13 @@ module EventMachine
         end
         control_connection.pasv
       end
+
+      def close
+        @control_connection.callback do 
+          yield if block_given?
+        end
+        @control_connection.close
+      end
     end
   end
 end

--- a/lib/em-ftp-client/session.rb
+++ b/lib/em-ftp-client/session.rb
@@ -47,6 +47,16 @@ module EventMachine
         end
         control_connection.pasv
       end
+
+      def put(file, &cb)
+        filename = File.basename(file)
+	      control_connection.callback do |data_connection|
+          data_connection.send_file(file)
+          control_connection.callback(&cb)
+          control_connection.stor filename
+        end
+        control_connection.pasv
+      end
     end
   end
 end

--- a/test/control_connection_test.rb
+++ b/test/control_connection_test.rb
@@ -177,6 +177,7 @@ class ControlConnectionTest < Test::Unit::TestCase
       @control_connection.receive_line(set[2]+"\r\n") if set[2]
     end
 
+    # test RETR
     @control_connection.expects(:send_data).with("RETR foo.txt\r\n")
     @control_connection.retr("foo.txt")
 
@@ -188,6 +189,17 @@ class ControlConnectionTest < Test::Unit::TestCase
     @data_connection.receive_data("Bar")
     @data_connection.unbind
     assert retr_completed
+
+    # test STOR
+    @control_connection.expects(:send_data).with("STOR foo.txt\r\n")
+    @control_connection.stor("foo.txt")
+
+    stor_completed = false
+    @control_connection.callback {stor_completed = true }
+    assert !stor_completed
+    @data_connection.unbind
+    @control_connection.receive_line("226 Hooray\r\n")
+    assert stor_completed
 
     assert started
     assert_equal "\"/foo\"", working_dir


### PR DESCRIPTION
The retr would fail if the control connection's success response code arrived earlier than the data connection's close. This situation was observed against a filezilla server running on windows.

Also, i implemented Session#put(file), which does a STOR
