### PR TITLE
Error handling for SyncSession

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ Gemfile.lock
 pkg/*
 .idea
 test_client.rb
+.DS_Store

--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -99,7 +99,7 @@ module EventMachine
           # Keep the @response since it is needed in data_connection_closed
           # dispatch appropriately
           if @response.success?
-            send(@responder, @response) if @responder
+            send(@responder, @response, @data_connection) if @responder
           elsif @response.mark?
             #maybe notice the mark or something
           elsif @response.failure?
@@ -113,8 +113,9 @@ module EventMachine
 
       def data_connection_closed(data)
         @data_buffer = data
+        data_connection = @data_connection
         @data_connection = nil
-        send(@responder) if @responder and @response.complete?
+        send(@responder, nil, data_connection) if @responder and @response.complete?
       end
 
       def callback(&blk)
@@ -198,30 +199,30 @@ module EventMachine
       # handlers
       
       # Called after initial connection
-      def receive_greetings(banner)
+      def receive_greetings(banner, data_connection)
         if banner.code == "220"
           user username
         end
       end
 
       # Called when a response for the USER verb is received
-      def user_response(response)
+      def user_response(response, data_connection)
         pass password
       end
 
       # Called when a response for the PASS verb is received
-      def password_response(response)
+      def password_response(response, data_connection)
         type "I"
       end
 
       # Called when a response for the TYPE verb is received
-      def type_response(response)
+      def type_response(response, data_connection)
         @responder = nil
         call_callback
       end
 
       # Called when a response for the CWD or CDUP is received
-      def cwd_response(response)
+      def cwd_response(response, data_connection)
         if response && response.code != "226"
           @responder = nil
           call_callback
@@ -229,7 +230,7 @@ module EventMachine
       end
 
       # Called when a response for the DELE is received
-      def dele_response(response)
+      def dele_response(response, data_connection)
         @responder = nil
         call_callback
       end
@@ -237,7 +238,7 @@ module EventMachine
       # Called when a response for the PWD verb is received
       #
       # Calls out with the result to the callback given to pwd
-      def pwd_response(response)
+      def pwd_response(response, data_connection)
         @responder = nil
         call_callback(response.body)
       end
@@ -245,7 +246,7 @@ module EventMachine
       # Called when a response for the PASV verb is received
       #
       # Opens a new data connection and executes the callback
-      def pasv_response(response)
+      def pasv_response(response, data_connection)
         @responder = nil
         if response.code == "227"
           if m = /(\d{1,3},\d{1,3},\d{1,3},\d{1,3}),(\d+),(\d+)/.match(response.body)
@@ -265,17 +266,17 @@ module EventMachine
         end
       end
 
-      def retr_response(response=nil)
+      def retr_response(response, data_connection)
         if response && response.code != "226"
-          @data_connection.close_connection
+          data_connection.close_connection
           @responder = nil
           error(response)
         end
 
-        if response && @data_connection
+        if response && data_connection
           @response = response
           #well we still gots to wait for the file
-        elsif @data_connection
+        elsif data_connection
           #well we need to wait for a response
         else
           @responder = nil
@@ -285,9 +286,9 @@ module EventMachine
         end
       end
 
-      def stor_response(response=nil)
+      def stor_response(response, data_connection)
         if response && response.code != "226"
-          @data_connection.close_connection
+          data_connection.close_connection
           @responder = nil
           error(response)
         end
@@ -297,16 +298,16 @@ module EventMachine
         call_callback
       end
 
-      def list_response(response=nil)
+      def list_response(response, data_connection)
         if response && response.code != "226"
-          @data_connection.close_connection
+          data_connection.close_connection
           @responder = nil
           error(response)
         end
 
-        if response && @data_connection
+        if response && data_connection
           #well we still gots to wait for the file
-        elsif @data_connection
+        elsif data_connection
           #well we need to wait for a response
         else
           @responder = nil
@@ -320,7 +321,7 @@ module EventMachine
         end
       end
       
-      def close_response(response=nil)
+      def close_response(response, data_connection)
         close_connection
         call_callback
       end

--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -78,6 +78,11 @@ module EventMachine
   
       def connection_completed
         @responder = :receive_greetings
+        @connected = true
+      end
+
+      def unbind
+        error(Errno::ETIMEDOUT.new) unless @connected
       end
 
       def error(e)

--- a/lib/em-ftp-client/control_connection.rb
+++ b/lib/em-ftp-client/control_connection.rb
@@ -184,6 +184,11 @@ module EventMachine
         @responder = :close_response
       end
 
+      def dele(filename)
+        send_data("DELE #{filename}\r\n")
+        @responder = :dele_response
+      end
+
       def list
         send_data("LIST\r\n")
         @responder = :list_response
@@ -220,6 +225,12 @@ module EventMachine
           @responder = nil
           call_callback
         end
+      end
+
+      # Called when a response for the DELE is received
+      def dele_response(response)
+        @responder = nil
+        call_callback
       end
 
       # Called when a response for the PWD verb is received

--- a/lib/em-ftp-client/session.rb
+++ b/lib/em-ftp-client/session.rb
@@ -67,6 +67,11 @@ module EventMachine
         end
         @control_connection.close
       end
+
+      def delete(file, &cb)
+        control_connection.callback(&cb)
+        control_connection.dele(file)
+      end
     end
   end
 end

--- a/lib/em-ftp-client/session.rb
+++ b/lib/em-ftp-client/session.rb
@@ -14,6 +14,9 @@ module EventMachine
         @control_connection = EM.connect(url, port, ControlConnection)
         @control_connection.username = username
         @control_connection.password = password
+        if options[:connect_timeout]
+          @control_connection.pending_connect_timeout = options[:connect_timeout]
+        end
         @control_connection.callback do
           cb.call(self)
         end

--- a/lib/em-ftp-client/sync_session.rb
+++ b/lib/em-ftp-client/sync_session.rb
@@ -61,9 +61,15 @@ begin
           f = Fiber.current
 
           error = nil
-          control_connection.errback { |response|
-            error = Error.new("FTP: #{response.code} #{response.body}")
-            error.response = response
+          control_connection.errback { |response_or_exception|
+            error = if response_or_exception.is_a?(Exception)
+                      response_or_exception
+                    else
+                      response = response_or_exception
+                      Error.new("FTP: #{response.code} #{response.body}").tap { |err|
+                        err.response = response
+                      }
+                    end
             f.resume
           }
 

--- a/lib/em-ftp-client/sync_session.rb
+++ b/lib/em-ftp-client/sync_session.rb
@@ -3,14 +3,19 @@ begin
 
   module EventMachine
     module FtpClient
+      class Error < StandardError
+        attr_accessor :response
+      end
+
       class SyncSession < Session
         def initialize(url, options={})
           f = Fiber.current
+
           super url, options do |conn|
             f.resume(conn)
           end
 
-          Fiber.yield
+          yield_with_error_handling
         end
 
         def pwd
@@ -19,7 +24,7 @@ begin
             f.resume(arg)
           end
 
-          Fiber.yield
+          yield_with_error_handling
         end
 
         def cwd(dir)
@@ -28,7 +33,7 @@ begin
             f.resume
           end
 
-          Fiber.yield
+          yield_with_error_handling
         end
 
         def list
@@ -37,7 +42,7 @@ begin
             f.resume(data)
           end
 
-          Fiber.yield
+          yield_with_error_handling
         end
 
         def get(file)
@@ -47,7 +52,24 @@ begin
             f.resume(data)
           end
 
-          Fiber.yield
+          yield_with_error_handling
+        end
+
+        private
+
+        def yield_with_error_handling
+          f = Fiber.current
+
+          error = nil
+          control_connection.errback { |response|
+            error = Error.new("FTP: #{response.code} #{response.body}")
+            error.response = response
+            f.resume
+          }
+
+          Fiber.yield.tap {
+            raise error if error
+          }
         end
       end
     end

--- a/lib/em-ftp-client/sync_session.rb
+++ b/lib/em-ftp-client/sync_session.rb
@@ -55,6 +55,15 @@ begin
           yield_with_error_handling
         end
 
+        def delete(file)
+          f = Fiber.current
+          super file do |data|
+            f.resume(data)
+          end
+
+          yield_with_error_handling
+        end
+
         private
 
         def yield_with_error_handling


### PR DESCRIPTION
Raises EventMachine::FtpClient::Error if anything goes wrong.
Response is available in the exception object.

No handling included for the asynchronous session.
